### PR TITLE
Fix config case mismatch and clarify button names

### DIFF
--- a/CaptureTool/ConfigManager.cs
+++ b/CaptureTool/ConfigManager.cs
@@ -21,10 +21,10 @@ namespace GakRehearsalCapture
 
             config["captureArea"] = new JObject
             {
-                ["X"] = selectedArea.X,
-                ["Y"] = selectedArea.Y,
-                ["Width"] = selectedArea.Width,
-                ["Height"] = selectedArea.Height
+                ["x"] = selectedArea.X,
+                ["y"] = selectedArea.Y,
+                ["width"] = selectedArea.Width,
+                ["height"] = selectedArea.Height
             };
 
             File.WriteAllText(configPath, config.ToString());
@@ -39,10 +39,10 @@ namespace GakRehearsalCapture
 
             var area = config["captureArea"];
             return new Rectangle(
-                (int)area["X"],
-                (int)area["Y"],
-                (int)area["Width"],
-                (int)area["Height"]
+                (int)area["x"],
+                (int)area["y"],
+                (int)area["width"],
+                (int)area["height"]
             );
         }
     }

--- a/CaptureTool/Form1.Designer.cs
+++ b/CaptureTool/Form1.Designer.cs
@@ -29,10 +29,10 @@
         private void InitializeComponent()
         {
             buttonSelectRange = new Button();
-            button2 = new Button();
+            buttonRunOcr = new Button();
             pictureBox1 = new PictureBox();
             labelStatus = new Label();
-            button1 = new Button();
+            buttonReread = new Button();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             SuspendLayout();
             // 
@@ -46,15 +46,15 @@
             buttonSelectRange.UseVisualStyleBackColor = true;
             buttonSelectRange.Click += buttonSelectRange_Click;
             // 
-            // button2
-            // 
-            button2.Location = new Point(12, 69);
-            button2.Name = "button2";
-            button2.Size = new Size(218, 52);
-            button2.TabIndex = 3;
-            button2.Text = "OCR実行";
-            button2.UseVisualStyleBackColor = true;
-            button2.Click += buttonOCR_Click;
+            // buttonRunOcr
+            //
+            buttonRunOcr.Location = new Point(12, 69);
+            buttonRunOcr.Name = "buttonRunOcr";
+            buttonRunOcr.Size = new Size(218, 52);
+            buttonRunOcr.TabIndex = 3;
+            buttonRunOcr.Text = "OCR実行";
+            buttonRunOcr.UseVisualStyleBackColor = true;
+            buttonRunOcr.Click += buttonRunOcr_Click;
             // 
             // pictureBox1
             // 
@@ -73,25 +73,25 @@
             labelStatus.TabIndex = 6;
             labelStatus.Text = "範囲を選択ボタンでリハーサル画面をキャプチャしてください";
             // 
-            // button1
-            // 
-            button1.Location = new Point(12, 127);
-            button1.Name = "button1";
-            button1.Size = new Size(218, 52);
-            button1.TabIndex = 7;
-            button1.Text = "今の選択範囲で読み取り直す";
-            button1.UseVisualStyleBackColor = true;
-            button1.Click += button1_Click;
+            // buttonReread
+            //
+            buttonReread.Location = new Point(12, 127);
+            buttonReread.Name = "buttonReread";
+            buttonReread.Size = new Size(218, 52);
+            buttonReread.TabIndex = 7;
+            buttonReread.Text = "今の選択範囲で読み取り直す";
+            buttonReread.UseVisualStyleBackColor = true;
+            buttonReread.Click += buttonReread_Click;
             // 
             // Form1
             // 
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(780, 730);
-            Controls.Add(button1);
+            Controls.Add(buttonReread);
             Controls.Add(labelStatus);
             Controls.Add(pictureBox1);
-            Controls.Add(button2);
+            Controls.Add(buttonRunOcr);
             Controls.Add(buttonSelectRange);
             Name = "Form1";
             Text = "Form1";
@@ -104,9 +104,9 @@
         #endregion
 
         private Button buttonSelectRange;
-        private Button button2;
+        private Button buttonRunOcr;
         private PictureBox pictureBox1;
         private Label labelStatus;
-        private Button button1;
+        private Button buttonReread;
     }
 }

--- a/CaptureTool/Form1.cs
+++ b/CaptureTool/Form1.cs
@@ -33,7 +33,7 @@ namespace GakRehearsalCapture
             }
         }
 
-        private async void buttonOCR_Click(object sender, EventArgs e)
+        private async void buttonRunOcr_Click(object sender, EventArgs e)
         {
             if (pictureBox1.Image != null)
             {
@@ -104,7 +104,7 @@ namespace GakRehearsalCapture
             }
         }
 
-        private void button1_Click(object sender, EventArgs e)
+        private void buttonReread_Click(object sender, EventArgs e)
         {
             Rectangle? area = ConfigManager.GetCaptureArea();
 


### PR DESCRIPTION
## Summary
- update ConfigManager to use lower case config keys
- rename unnamed buttons and events for clarity

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea66e823883258cc8ae52600e8220