### PR TITLE
feat: OCR実行回数の表示とリセット機能を追加

### DIFF
--- a/CaptureTool/Form1.Designer.cs
+++ b/CaptureTool/Form1.Designer.cs
@@ -33,6 +33,8 @@
             pictureBox1 = new PictureBox();
             labelStatus = new Label();
             buttonReread = new Button();
+            labelOcrCount = new Label();
+            buttonResetCount = new Button();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             SuspendLayout();
             // 
@@ -63,11 +65,29 @@
             pictureBox1.Size = new Size(373, 705);
             pictureBox1.TabIndex = 5;
             pictureBox1.TabStop = false;
-            // 
+            //
+            // labelOcrCount
+            //
+            labelOcrCount.AutoSize = true;
+            labelOcrCount.Location = new Point(12, 187);
+            labelOcrCount.Name = "labelOcrCount";
+            labelOcrCount.TabIndex = 8;
+            labelOcrCount.Text = "OCR実行回数: 0";
+            //
+            // buttonResetCount
+            //
+            buttonResetCount.Location = new Point(12, 207);
+            buttonResetCount.Name = "buttonResetCount";
+            buttonResetCount.Size = new Size(218, 40);
+            buttonResetCount.TabIndex = 9;
+            buttonResetCount.Text = "回数をリセット";
+            buttonResetCount.UseVisualStyleBackColor = true;
+            buttonResetCount.Click += buttonResetCount_Click;
+            //
             // labelStatus
-            // 
+            //
             labelStatus.AutoSize = true;
-            labelStatus.Location = new Point(12, 182);
+            labelStatus.Location = new Point(12, 257);
             labelStatus.Name = "labelStatus";
             labelStatus.Size = new Size(273, 15);
             labelStatus.TabIndex = 6;
@@ -88,6 +108,8 @@
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(780, 730);
+            Controls.Add(buttonResetCount);
+            Controls.Add(labelOcrCount);
             Controls.Add(buttonReread);
             Controls.Add(labelStatus);
             Controls.Add(pictureBox1);
@@ -108,5 +130,7 @@
         private PictureBox pictureBox1;
         private Label labelStatus;
         private Button buttonReread;
+        private Label labelOcrCount;
+        private Button buttonResetCount;
     }
 }

--- a/CaptureTool/Form1.cs
+++ b/CaptureTool/Form1.cs
@@ -8,6 +8,7 @@ namespace GakRehearsalCapture
     {
 
         private string lastOcrResult = string.Empty;
+        private int ocrCount = 0;
 
         public Form1()
         {
@@ -56,6 +57,8 @@ namespace GakRehearsalCapture
         {
             var result = PerformOcr(bitmap);
             lastOcrResult = result.Csv;
+            ocrCount++;
+            labelOcrCount.Text = $"OCR実行回数: {ocrCount}";
             if (string.IsNullOrEmpty(lastOcrResult))
             {
                 labelStatus.Text = "数字が検出されませんでした";
@@ -64,6 +67,12 @@ namespace GakRehearsalCapture
             {
                 labelStatus.Text = result.Preview;
             }
+        }
+
+        private void buttonResetCount_Click(object sender, EventArgs e)
+        {
+            ocrCount = 0;
+            labelOcrCount.Text = $"OCR実行回数: {ocrCount}";
         }
 
         private Pix BitmapToPix(Bitmap bitmap)


### PR DESCRIPTION
## Summary
- OCR実行のたびにカウントアップし、画面上に「OCR実行回数: N」と表示する `labelOcrCount` を追加
- カウントを0にリセットする「回数をリセット」ボタン (`buttonResetCount`) を追加
- `labelStatus` の位置を下方向に移動し、新しいUIと重ならないよう調整

## Test plan
- [ ] 範囲を選択してOCRを実行し、カウントが増加することを確認
- [ ] 「今の選択範囲で読み取り直す」ボタンでもカウントが増加することを確認
- [ ] 「回数をリセット」ボタンでカウントが0に戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)